### PR TITLE
Fix build failure by checking logs

### DIFF
--- a/.github/workflows/flutter-release.yml
+++ b/.github/workflows/flutter-release.yml
@@ -18,9 +18,10 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: '17.x'
+          java-version: '17'
+          distribution: 'temurin'
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -16,9 +16,10 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: '17.x'
+          java-version: '17'
+          distribution: 'temurin'
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:

--- a/BUILD_FIXES_SUMMARY.md
+++ b/BUILD_FIXES_SUMMARY.md
@@ -1,0 +1,86 @@
+# Build Fixes Applied
+
+## Issues Identified and Fixed
+
+### 1. **Android Flavor Mismatch - CRITICAL**
+**Problem**: The `Makefile` was trying to build with `--flavor main` but only `unsigned` and `production` flavors exist in the Android `build.gradle` configuration.
+
+**Fix**: Updated `Makefile` line 18:
+```diff
+- $(FLUTTER) build apk --release --build-number=$(VERSION) --flavor main
++ $(FLUTTER) build apk --release --build-number=$(VERSION) --flavor production
+```
+
+**Impact**: This was likely causing all Android release builds to fail in both GitHub Actions and Drone CI.
+
+### 2. **Deprecated GitHub Actions**
+**Problem**: Using deprecated `actions/setup-java@v1` which may cause build failures.
+
+**Fix**: Updated both `.github/workflows/flutter.yml` and `.github/workflows/flutter-release.yml`:
+```diff
+- uses: actions/setup-java@v1
++ uses: actions/setup-java@v4
+  with:
+-   java-version: '17.x'
++   java-version: '17'
++   distribution: 'temurin'
+```
+
+**Impact**: The deprecated action could cause inconsistent behavior or eventual failure as GitHub phases out v1 actions.
+
+## Current Build Configuration Status
+
+### Android Builds
+- ✅ **Fixed**: Flavor mismatch resolved
+- ✅ **Fixed**: Java setup action updated
+- ✅ **Good**: Android builds have `continue-on-error: true` to prevent blocking workflows
+- ✅ **Good**: Both `unsigned` and `production` flavors properly configured
+
+### iOS Builds
+- ✅ **Good**: Comprehensive CocoaPods retry logic
+- ✅ **Good**: Proper code signing setup with Fastlane
+- ✅ **Good**: Separate unsigned and signed build jobs
+- ✅ **Good**: Export options properly configured
+
+### Available Build Commands
+- `make build-debug` - Debug APK with unsigned flavor
+- `make build-release` - Release APK with production flavor (now fixed)
+- `make build-profile` - Profile APK with unsigned flavor
+- `make build-ios` - iOS build without code signing
+- `make build-all` - All Android builds
+
+## Expected Behavior After Fixes
+
+### GitHub Actions
+1. **PR/Push to non-main branches**: 
+   - Android debug builds should work
+   - iOS unsigned IPA generation should work
+   - Linting and formatting checks should pass
+
+2. **Push to main branch**:
+   - Android release builds should work with production flavor
+   - iOS signed IPA generation and TestFlight upload should work (if secrets configured)
+
+### Drone CI
+1. **Testing pipeline**: Debug builds should work
+2. **Release pipelines**: Release builds should work with correct flavor
+3. **iOS pipeline**: Should work with updated dependencies
+
+## Required Secrets (for iOS signing)
+- `MATCH_PASSWORD` - Fastlane Match password
+- `FASTLANE_PASSWORD` - Apple ID password  
+- `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD` - App-specific password
+- `FASTLANE_SESSION` - Fastlane session token
+- `KEYCHAIN_PASSWORD` - Keychain password
+- Contact info secrets for TestFlight
+
+## Next Steps
+1. Test the builds with the fixed configuration
+2. Monitor workflow runs for any remaining issues
+3. Update any remaining deprecated actions if found
+4. Consider updating Flutter version constraint in pubspec.yaml to match workflow usage
+
+## Files Modified
+- `Makefile` - Fixed Android flavor for release builds
+- `.github/workflows/flutter.yml` - Updated Java setup action
+- `.github/workflows/flutter-release.yml` - Updated Java setup action

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build-all: build-release build-debug build-profile
 
 .PHONY: build-release
 build-release:
-	$(FLUTTER) build apk --release --build-number=$(VERSION) --flavor main
+	$(FLUTTER) build apk --release --build-number=$(VERSION) --flavor production
 
 .PHONY: build-debug
 build-debug:


### PR DESCRIPTION
Fix Android build failures by correcting flavor and updating deprecated GitHub Actions.

The `Makefile` was attempting to build Android with a non-existent `main` flavor, causing release builds to fail. Additionally, deprecated `actions/setup-java@v1` was updated to `v4` for improved CI reliability.